### PR TITLE
Optionally, only space a subset of glyphs within a UFO

### DIFF
--- a/src/htletterspacer/__main__.py
+++ b/src/htletterspacer/__main__.py
@@ -5,6 +5,7 @@ import collections
 import functools
 import logging
 import sys
+from os import PathLike
 from pathlib import Path
 
 import ufoLib2
@@ -70,7 +71,7 @@ def space_ufo(
     area: int | None = None,
     depth: int | None = None,
     overshoot: int | None = None,
-    config_file: Path | None = None,
+    config_file: PathLike[str] | None = None,
     to_space: set[str] | None = None,
     debug_polygons_in_background: bool = False,
 ) -> None:
@@ -83,7 +84,7 @@ def space_ufo(
     param_over: int = overshoot or ufo.lib.get(OVERSHOOT_KEY, 0)
 
     if config_file is not None:
-        config = htletterspacer.config.parse_config(config_file.read_text())
+        config = htletterspacer.config.parse_config(Path(config_file).read_text())
     else:
         config = htletterspacer.config.parse_config(
             htletterspacer.config.DEFAULT_CONFIGURATION


### PR DESCRIPTION
This change allows one to pass a set of glyph names to be considered, in place of consuming the entire UFO.

In addition, this commit refactors the `space_ufo` function to take keyword arguments instead of an argparse.Namespace, to allow for easier calling as a library.